### PR TITLE
feat: Add initial setup.py for 'git-commit-bot' package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="git-commit-bot",
+    version="0.1.0",
+    packages=find_packages(),
+    install_requires=[
+        "openai",
+    ],
+    py_modules=['main'],
+    entry_points={
+        'console_scripts': [
+            'git-commit-bot=main:main',  # Points to root main.py
+        ],
+    },
+    python_requires=">=3.7",
+)


### PR DESCRIPTION
This commit introduces the initial setup.py file needed for the 'git-commit-bot' package. It specifies the package name, version, dependencies, and Python version requirement. It also sets up 'git-commit-bot' as a console script pointing to main.py.